### PR TITLE
Removed data-branch from version.html (platform-29)

### DIFF
--- a/version.html
+++ b/version.html
@@ -16,7 +16,7 @@
       <dd>{{APPVEYOR_BUILD_VERSION}}</dd>
 
       <dt>{{REPO}} commit:</dt>
-      <dd data-repo="dccouncil/{{REPO}}" data-branch="master">{{COMMIT}}</dd>
+      <dd data-repo="dccouncil/{{REPO}}">{{COMMIT}}</dd>
 
       <dt>Date:</dt>
       <dd>{{DATE}}</dd>


### PR DESCRIPTION
Specifying the branch is no longer supported due to the changes in openlawlibrary/OpenLawPlatform#29.

*This needs to get merged into `master` as well.*

Tagging @dgreisen since I can't set the Reviewer/Assignee.